### PR TITLE
feat: enable configuring a prefix for device properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,8 +28,8 @@ dependencies = [
 
 [[package]]
 name = "akri-discovery-utils"
-version = "0.12.20"
-source = "git+https://github.com/project-akri/akri?branch=main#58e2371f93ab229039d1916f3dd7b4810af202fa"
+version = "0.13.5"
+source = "git+https://github.com/project-akri/akri?branch=main#49eb2256dcea9e7c12e913273b51770f6ae04e18"
 dependencies = [
  "akri-shared",
  "anyhow",
@@ -49,8 +49,8 @@ dependencies = [
 
 [[package]]
 name = "akri-shared"
-version = "0.12.20"
-source = "git+https://github.com/project-akri/akri?branch=main#58e2371f93ab229039d1916f3dd7b4810af202fa"
+version = "0.13.5"
+source = "git+https://github.com/project-akri/akri?branch=main#49eb2256dcea9e7c12e913273b51770f6ae04e18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anyhow"
@@ -200,21 +200,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -326,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -336,27 +330,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -373,27 +367,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -492,21 +465,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -794,21 +752,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-openssl"
-version = "0.9.2"
+name = "hyper-rustls"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "parking_lot 0.12.1",
+ "log",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-openssl",
- "tower-layer",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -904,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -927,23 +883,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
+name = "jsonpath-rust"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+checksum = "06cc127b7c3d270be504572364f9569761a180b981919dd0d87693a7f5fb7829"
 dependencies = [
- "log",
- "serde",
+ "pest",
+ "pest_derive",
+ "regex",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "k8s-openapi"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
+checksum = "edc3606fd16aca7989db2f84bb25684d0270c6d6fa1dbcd0025af7b4130523a6"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "schemars",
@@ -954,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.80.0"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414d80c69906a91e8ecf4ae16d0fb504e19aa6b099135d35d85298b4e4be3ed3"
+checksum = "3499c8d60c763246c7a213f51caac1e9033f46026904cb89bc8951ae8601f26e"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -966,27 +924,28 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.80.0"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc5ae0b9148b4e2ebb0dabda06a0cd65b1eed2f41d792d49787841a68050283"
+checksum = "033450dfa0762130565890dadf2f8835faedf749376ca13345bcd8ecd6b5f29f"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.7",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
+ "home",
  "http",
  "http-body",
  "hyper",
- "hyper-openssl",
+ "hyper-rustls",
  "hyper-timeout",
- "jsonpath_lib",
+ "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
  "pin-project",
+ "rustls",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -1001,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.80.0"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98331c6f1354893f7c50da069e43a3fd1c84e55bbedc7765d9db22ec3291d07d"
+checksum = "b5bba93d054786eba7994d03ce522f368ef7d48c88a1826faa28478d85fb63ae"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1018,15 +977,15 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.80.0"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be6ff26b9a34ce831d341e8b33bc78986a33c1be88f5bf9ca84e92e98b1dfb"
+checksum = "91e98dd5e5767c7b894c1f0e41fd628b145f808e981feb8b08ed66455d47f1a4"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1040,32 +999,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.4.2",
- "libc",
- "redox_syscall 0.4.1",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1255,48 +1188,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1357,11 +1252,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -1371,10 +1267,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.4"
+name = "pest"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.2.4",
@@ -1413,12 +1354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
  "syn 2.0.52",
@@ -1534,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1615,17 +1550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -1925,7 +1849,6 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.2.4",
  "itoa",
  "ryu",
  "serde",
@@ -1955,14 +1878,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.2.4",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1970,6 +1894,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2027,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -2162,18 +2097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
-dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,18 +2208,19 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.7",
+ "bitflags 2.4.2",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-range-header",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -2379,6 +2303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,12 +2373,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2743,15 +2673,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Nicolas Belouin <nicolas.belouin@suse.com>"]
 edition = "2018"
 
 [dependencies]
-# TODO: Change this to Akri main when the library is merged
 akri-discovery-utils = { git = "https://github.com/project-akri/akri", branch = "main", package = "akri-discovery-utils" }
 async-trait = "0.1.0"
 env_logger = "0.10.0"

--- a/Dockerfile.discovery-handler
+++ b/Dockerfile.discovery-handler
@@ -1,15 +1,16 @@
-ARG RUST_VERSION=1.73.0
+ARG RUST_VERSION=1.79.0
 FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION} as build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends protobuf-compiler 
 ARG TARGETPLATFORM RUST_VERSION
-RUN case "$TARGETPLATFORM" in \
+RUN RUST_TARGET=$( \
+  case "$TARGETPLATFORM" in \
     "linux/arm/v7") echo "armv7-unknown-linux-gnueabihf";; \
     "linux/arm64") echo "aarch64-unknown-linux-gnu";; \
     "linux/amd64") echo "x86_64-unknown-linux-gnu";; \
     *) exit 1;; \
-    esac > /rust_target
-RUN rustup target add --toolchain $RUST_VERSION $(cat /rust_target)
+  esac ) && \
+  rustup target add --toolchain $RUST_VERSION $RUST_TARGET
 RUN rustup component add rustfmt --toolchain $RUST_VERSION
 RUN USER=root cargo new --bin dh
 WORKDIR /dh

--- a/README.md
+++ b/README.md
@@ -2,3 +2,32 @@
 
 A simple Discovery Handler for MQTT based devices, aims to be a reference implementation for [MQTT akri proposal](https://github.com/project-akri/akri-docs/pull/80).
 
+## Deploy
+
+```sh
+  helm upgrade akri akri-helm-charts/akri \
+  $AKRI_HELM_CRICTL_CONFIGURATION \
+  --set custom.discovery.enabled=true  \
+  --set custom.discovery.image.repository=ghcr.io/myusername/mqtt-discovery-handler \
+  --set custom.discovery.image.tag=v1 \
+  --set custom.discovery.name=akri-mqtt-discovery 
+```
+
+## Build
+
+```sh
+docker buildx build --platform linux/arm64,linux/amd64 -t ghcr.io/myuser/mqtt-discovery-handler:v1 -f Dockerfile.discovery-handler .
+```
+
+> Note: this does not seem to be executing correctly once built
+
+## Run Locally
+```sh
+sudo -E RUST_LOG=info DISCOVERY_HANDLERS_DIRECTORY=/var/lib/akri AGENT_NODE_NAME=nodename $HOME/.cargo/bin/cargo run
+```
+
+## Apply Configuration
+
+```sh
+kubectl apply -f deploy/akri-mqtt-configuration.yaml
+```

--- a/deploy/akri-mqtt-configuration.yaml
+++ b/deploy/akri-mqtt-configuration.yaml
@@ -1,0 +1,32 @@
+apiVersion: akri.sh/v0
+kind: Configuration
+metadata:
+  name: akri-mqtt
+spec:
+  discoveryHandler:
+    name: mqtt
+    discoveryDetails: |+
+        mqttBrokerUri: "tcp://192.168.1.14:1883"
+        topics: ["hello", "goodbye", "wow"]
+        timeoutSeconds: 60
+  brokerSpec:
+    brokerPodSpec:
+      containers:
+      - name: akri-mqtt-broker
+        image: "nginx:stable-alpine"
+        imagePullPolicy: Always
+        resources:
+          limits:
+            "{{PLACEHOLDER}}" : "1"
+  instanceServiceSpec:
+    ports:
+    - name: grpc
+      port: 80
+      targetPort: 8083
+  configurationServiceSpec:
+    ports:
+    - name: grpc
+      port: 80
+      targetPort: 8083
+  brokerProperties: {}
+  capacity: 5

--- a/src/discovery_handler.rs
+++ b/src/discovery_handler.rs
@@ -36,6 +36,7 @@ pub struct MqttDiscoveryDetails {
     pub timeout_seconds: i64,
     #[serde(default, skip_serializing_if = "Option::is_none", with = "serde_regex")]
     pub message_regexp: Option<Regex>,
+    pub properties_prefix: Option<String>,
 }
 
 pub struct DiscoveryHandlerImpl {
@@ -83,7 +84,11 @@ fn authenticate_mqtt(
                 .ok_or(invalid_arg("password is empty"))?,
         )
         .map_err(|e| invalid_arg(format!("unable to parse password: {}", e)))?;
-        mqttoptions.set_credentials(username, password);
+        if !username.is_empty() && !password.is_empty() {
+            mqttoptions.set_credentials(username, password);
+        } else {
+            info!("No username or password provided -- skipping authentication")
+        }
     }
     Ok(())
 }
@@ -105,11 +110,13 @@ fn get_certificate_and_key(
                 .iter()
                 .chain(
                     rustls_pemfile::ec_private_keys(&mut &raw_key[..])
-                        .map_err(|e| invalid_arg(format!("Cannot parse key: {}", e)))?.iter(),
+                        .map_err(|e| invalid_arg(format!("Cannot parse key: {}", e)))?
+                        .iter(),
                 )
                 .chain(
                     rustls_pemfile::rsa_private_keys(&mut &raw_key[..])
-                        .map_err(|e| invalid_arg(format!("Cannot parse key: {}", e)))?.iter(),
+                        .map_err(|e| invalid_arg(format!("Cannot parse key: {}", e)))?
+                        .iter(),
                 )
                 .next()
                 .ok_or(invalid_arg("No key found"))?
@@ -174,6 +181,16 @@ impl DiscoveryHandler for DiscoveryHandlerImpl {
             deserialize_discovery_details(&discover_request.discovery_details)
                 .map_err(|e| tonic::Status::new(tonic::Code::InvalidArgument, format!("{}", e)))?;
 
+        info!(
+            "discover - mqtt_broker_uri: {}",
+            discovery_handler_config.mqtt_broker_uri
+        );
+        info!("discover - topics: {:?}", discovery_handler_config.topics);
+        info!(
+            "discover - timeout_seconds: {}",
+            discovery_handler_config.timeout_seconds
+        );
+
         let mut mqttoptions = MqttOptions::try_from(fill_client_id_if_needed(
             discovery_handler_config.mqtt_broker_uri.clone(),
         ))
@@ -209,6 +226,7 @@ impl DiscoveryHandler for DiscoveryHandlerImpl {
                 match mqtt_eventloop.poll().await {
                     Ok(Event::Incoming(Packet::Publish(notification))) => {
                         let topic = String::from_utf8(notification.topic.to_vec()).unwrap();
+                        info!("Received message on topic: {}", topic);
                         message_received_sender
                             .send(Action::Add(topic))
                             .await
@@ -272,18 +290,17 @@ impl DiscoveryHandler for DiscoveryHandlerImpl {
                         }
                         None => {
                             has_changed = true;
+                            info!("Adding device with topic: {}", topic);
                             discovered_devices.insert(
                                 topic.clone(),
                                 TimedDevice::new(
                                     Device {
                                         id: topic.clone(),
-                                        properties: HashMap::from([
-                                            ("MQTT_TOPIC".to_string(), topic.clone()),
-                                            (
-                                                "MQTT_BROKER_URI".to_string(),
-                                                mqtt_uri_string.clone(),
-                                            ),
-                                        ]),
+                                        properties: discovery_properties(
+                                            topic.clone(),
+                                            mqtt_uri_string.clone(),
+                                            &discovery_handler_config.properties_prefix,
+                                        ),
                                         mounts: Vec::default(),
                                         device_specs: Vec::default(),
                                     },
@@ -340,6 +357,28 @@ impl DiscoveryHandler for DiscoveryHandlerImpl {
             discovered_devices_receiver,
         )))
     }
+}
+
+fn discovery_properties(
+    topic: String,
+    uri: String,
+    properties_prefix: &Option<String>,
+) -> HashMap<String, String> {
+    let prefix = properties_prefix
+        .as_ref()
+        .map(|p| {
+            if p.ends_with('_') {
+                p.to_owned()
+            } else {
+                format!("{}_", p)
+            }
+        })
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    HashMap::from([
+        (format!("{prefix}MQTT_TOPIC"), topic),
+        (format!("{prefix}MQTT_BROKER_URI"), uri),
+    ])
 }
 
 #[cfg(test)]
@@ -451,5 +490,39 @@ B4Ezkc5fwpO+sXf2WKI3tktXYlITEcLPxPOxTSUUOpzY9JY9
     fn test_get_certificate_and_key_empty() -> Result<(), Status> {
         assert!(get_certificate_and_key(&HashMap::default())?.is_none());
         Ok(())
+    }
+
+    #[test]
+    fn test_discovery_details_deserialization_without_properties_prefix() {
+        use super::{deserialize_discovery_details, MqttDiscoveryDetails};
+        let discovery_details = r#"{
+            "mqttBrokerUri": "tcp://localhost:1883",
+            "topics": ["topic1", "topic2"],
+            "timeoutSeconds": 10
+        }"#;
+        let discovery_handler_config: MqttDiscoveryDetails =
+            deserialize_discovery_details(discovery_details).unwrap();
+        assert_eq!(discovery_handler_config.properties_prefix, None);
+    }
+
+    #[test]
+    fn test_discovery_properties() {
+        use super::discovery_properties;
+        let topic = "topic".to_string();
+        let uri = "tcp://localhost:1883".to_string();
+        let properties =
+            discovery_properties(topic.clone(), uri.clone(), &Some("prefix".to_string()));
+        assert_eq!(properties.len(), 2);
+        assert_eq!(properties.get("PREFIX_MQTT_TOPIC").unwrap(), &topic);
+        assert_eq!(properties.get("PREFIX_MQTT_BROKER_URI").unwrap(), &uri);
+        let properties =
+            discovery_properties(topic.clone(), uri.clone(), &Some("prefix_".to_string()));
+        assert_eq!(properties.len(), 2);
+        assert_eq!(properties.get("PREFIX_MQTT_TOPIC").unwrap(), &topic);
+        assert_eq!(properties.get("PREFIX_MQTT_BROKER_URI").unwrap(), &uri);
+        let properties = discovery_properties(topic.clone(), uri.clone(), &None);
+        assert_eq!(properties.len(), 2);
+        assert_eq!(properties.get("MQTT_TOPIC").unwrap(), &topic);
+        assert_eq!(properties.get("MQTT_BROKER_URI").unwrap(), &uri);
     }
 }

--- a/src/discovery_impl.rs
+++ b/src/discovery_impl.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use akri_discovery_utils::discovery::v0::Device;
+use log::info;
 use rumqttc::v5::ConnectionError;
 use tokio::{
     sync::mpsc::{self, Sender},
@@ -31,6 +32,7 @@ impl TimedDevice {
                 if let Ok(Some(_)) = timeout(timeout_duration, local_receiver.recv()).await {
                     continue;
                 }
+                info!("Device {} timed out", topic_clone.clone());
                 delete_sender
                     .send(Action::Delete(topic_clone.clone()))
                     .await


### PR DESCRIPTION
Some brokers, such as Spin Wasm apps may be opinionated about container broker env prefixes. This makes it configurable.

cc @diconico07 